### PR TITLE
pin progenitor to 0.1.1

### DIFF
--- a/zerotier-central-api/Cargo.lock
+++ b/zerotier-central-api/Cargo.lock
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "zerotier-central-api"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/zerotier-central-api/Cargo.toml
+++ b/zerotier-central-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zerotier-central-api"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 description = "ZeroTier Central API for Rust"
 authors = ["Erik Hollensbe <erik.hollensbe@zerotier.com>", "Adam Ierymenko <adam.ierymenko@zerotier.com>"]
@@ -17,5 +17,5 @@ serde_json = "1.0"
 
 [build-dependencies]
 anyhow = ">=0"
-progenitor = ">=0"
+progenitor = "0.1.1"
 serde_json = "1.0"

--- a/zerotier-central-api/openapi.json
+++ b/zerotier-central-api/openapi.json
@@ -1447,6 +1447,31 @@
               "$ref": "#/components/schemas/OrganizationMember"
             },
             "description": "List of organization members"
+          },
+          "ssoConfig": {
+            "type": "object",
+            "$ref": "#/components/schemas/SsoConfig",
+            "description": "Organization wide SSO configuration"
+          }
+        }
+      },
+      "SsoConfig": {
+        "type": "object",
+        "properties": {
+          "clientId": {
+            "type": "string",
+            "example": "oidc-client-id",
+            "description": "OIDC Client ID"
+          },
+          "issuer": {
+            "type": "string",
+            "example": "https://example.com/oidc/auth",
+            "description": "OIDC Issuer URL"
+          },
+          "enabled": {
+            "type": "boolean",
+            "example": true,
+            "description": "Enabled flag for SSO"
           }
         }
       },

--- a/zerotier-one-api/Cargo.toml
+++ b/zerotier-one-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zerotier-one-api"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 description = "OpenAPI bindings to the ZeroTierOne JSON API"
 authors = ["Erik Hollensbe <erik.hollensbe@zerotier.com>", "Adam Ierymenko <adam.ierymenko@zerotier.com>"]
@@ -17,5 +17,5 @@ serde_json = "1.0"
 
 [build-dependencies]
 anyhow = ">=0"
-progenitor = ">=0"
+progenitor = "0.1.1"
 serde_json = "1.0"


### PR DESCRIPTION
api changes in progenitor 0.2.0 are breaking builds.  do this until we can further investigate API changes needed for 0.2.0+